### PR TITLE
Only allow 1 copy to be running on a table at a time

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -110,6 +110,7 @@
               <!-- automatically creates the classpath using all project dependencies,
                    also adding the project build directory -->
               <classpath/>
+              <argument>-XX:+HeapDumpOnOutOfMemoryError</argument>
               <argument>com.patreon.euphrates.App</argument>
             </arguments>
           </configuration>

--- a/pom.xml
+++ b/pom.xml
@@ -105,7 +105,7 @@
           <configuration>
             <executable>java</executable>
             <arguments>
-              <argument>-Xmx8192m</argument>
+              <argument>-Xmx12288m</argument>
               <argument>-classpath</argument>
               <!-- automatically creates the classpath using all project dependencies,
                    also adding the project build directory -->

--- a/pom.xml
+++ b/pom.xml
@@ -105,7 +105,7 @@
           <configuration>
             <executable>java</executable>
             <arguments>
-              <argument>-Xmx12288m</argument>
+              <argument>-Xmx11264m</argument>
               <argument>-classpath</argument>
               <!-- automatically creates the classpath using all project dependencies,
                    also adding the project build directory -->

--- a/pom.xml
+++ b/pom.xml
@@ -105,7 +105,7 @@
           <configuration>
             <executable>java</executable>
             <arguments>
-              <argument>-Xmx11264m</argument>
+              <argument>-Xmx8192m</argument>
               <argument>-classpath</argument>
               <!-- automatically creates the classpath using all project dependencies,
                    also adding the project build directory -->

--- a/src/main/java/com/patreon/euphrates/S3Writer.java
+++ b/src/main/java/com/patreon/euphrates/S3Writer.java
@@ -257,6 +257,7 @@ public class S3Writer {
         }
         writer.flush();
         writer.close();
+        rows.clear();
         LOG.debug(String.format("closing %s", file));
         String key = String.format("%s/%s.json.gz", table.name, id);
         s3Writer.getClient().putObject(replicator.getConfig().s3.bucket, key, file);

--- a/src/main/java/com/patreon/euphrates/S3Writer.java
+++ b/src/main/java/com/patreon/euphrates/S3Writer.java
@@ -155,7 +155,7 @@ public class S3Writer {
             BlockingQueue<CopyJob> queue = copyEntry.getValue();
 
             currentTableLock = tableCopyLocks.get(currentTableName);
-            if (!currentTableLock.tryLock(1, TimeUnit.SECONDS)) {
+            if (!currentTableLock.tryLock()) {
               LOG.debug("Unable to acquire lock for table {}, so going to process other queues", currentTableName);
               continue;
             }

--- a/src/main/java/com/patreon/euphrates/S3Writer.java
+++ b/src/main/java/com/patreon/euphrates/S3Writer.java
@@ -21,7 +21,7 @@ import java.util.zip.GZIPOutputStream;
 public class S3Writer {
 
   private static final Logger LOG = LoggerFactory.getLogger(S3Writer.class);
-  private static final int TABLE_QUEUE_SIZE = 10000;
+  private static final int TABLE_QUEUE_SIZE = 20000;
   AmazonS3 client;
   Replicator replicator;
   ThreadPoolExecutor uploader;

--- a/src/main/java/com/patreon/euphrates/S3Writer.java
+++ b/src/main/java/com/patreon/euphrates/S3Writer.java
@@ -155,7 +155,6 @@ public class S3Writer {
 
             ReentrantLock currentTableLock = tableCopyLocks.get(currentTableName);
             if (!currentTableLock.tryLock()) {
-              LOG.debug("Unable to acquire lock for table {}, so going to process other queues", currentTableName);
               continue;
             }
 
@@ -206,7 +205,7 @@ public class S3Writer {
                       manifestPath,
                       mapper.writeValueAsString(manifest));
 
-      LOG.info(String.format("trying %s with %s size manifest", table.name, jobs.size()));
+      LOG.info(String.format("copying to %s with %s segments", table.name, jobs.size()));
       replicator.getRedshift().copyManifestPath(table, manifestPath);
       for (CopyJob job : jobs) {
         job.getFinished().decrement();

--- a/src/main/java/com/patreon/euphrates/StreamParser.java
+++ b/src/main/java/com/patreon/euphrates/StreamParser.java
@@ -43,7 +43,7 @@ public class StreamParser {
       int columnIndex = -1;
       int valueCount = -1;
       int size = 0;
-      StringBuilder currentValue = new StringBuilder();
+      StringBuilder currentValue = null;
       while (reader.hasNext()) {
         int type = reader.next();
         switch (type) {
@@ -88,8 +88,8 @@ public class StreamParser {
                 break;
               case "field":
                 if (columnIndex != -1) {
-                  currentRow.set(columnIndex, currentValue.toString());
-                  currentValue = new StringBuilder();
+                  currentRow.set(columnIndex, currentValue == null ? null : currentValue.toString());
+                  currentValue = null;
                   valueCount--;
                   columnIndex = -1;
                 }
@@ -98,6 +98,7 @@ public class StreamParser {
             break;
           case XMLStreamReader.CHARACTERS:
             if (columnIndex != -1) {
+              if (currentValue == null) currentValue = new StringBuilder();
               currentValue.append(reader.getText());
             }
             break;


### PR DESCRIPTION
We don't want more than 1 COPY running on a table at a time, so make a mapping of table name -> locks, and make the copy jobs get the lock before trying to copy.