### PR TITLE
Add basic test, handle multibyte sequences

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,40 @@
+# Java Maven CircleCI 2.0 configuration file
+#
+# Check https://circleci.com/docs/2.0/language-java/ for more details
+version: 2
+jobs:
+  build:
+    docker:
+      # specify the version you desire here
+      - image: circleci/openjdk:8-jdk
+
+      # Specify service dependencies here if necessary
+      # CircleCI maintains a library of pre-built images
+      # documented at https://circleci.com/docs/2.0/circleci-images/
+      # - image: circleci/postgres:9.4
+
+    working_directory: ~/repo
+
+    environment:
+      # Customize the JVM maximum heap limit
+      MAVEN_OPTS: -Xmx3200m
+
+    steps:
+      - checkout
+
+      # Download and cache dependencies
+      - restore_cache:
+          keys:
+          - v1-dependencies-{{ checksum "pom.xml" }}
+          # fallback to using the latest cache if no exact match is found
+          - v1-dependencies-
+
+      - run: mvn dependency:go-offline
+
+      - save_cache:
+          paths:
+            - ~/.m2
+          key: v1-dependencies-{{ checksum "pom.xml" }}
+
+      # run tests!
+      - run: mvn test

--- a/pom.xml
+++ b/pom.xml
@@ -23,13 +23,6 @@
 
   <dependencies>
     <dependency>
-      <groupId>junit</groupId>
-      <artifactId>junit</artifactId>
-      <version>3.8.1</version>
-      <scope>test</scope>
-    </dependency>
-      <!-- https://mvnrepository.com/artifact/postgresql/postgresql -->
-    <dependency>
        <groupId>com.amazon.redshift</groupId>
        <artifactId>redshift-jdbc42</artifactId>
        <version>1.2.1.1001</version>
@@ -83,6 +76,19 @@
         <artifactId>sentry-log4j2</artifactId>
         <version>1.7.3</version>
     </dependency>
+      <!-- https://mvnrepository.com/artifact/junit/junit -->
+      <dependency>
+          <groupId>junit</groupId>
+          <artifactId>junit</artifactId>
+          <version>4.12</version>
+          <scope>test</scope>
+      </dependency>
+      <dependency>
+          <groupId>commons-io</groupId>
+          <artifactId>commons-io</artifactId>
+          <version>2.6</version>
+          <scope>test</scope>
+      </dependency>
   </dependencies>
 
   <build>

--- a/src/main/java/com/patreon/euphrates/ScrubbingInputStream.java
+++ b/src/main/java/com/patreon/euphrates/ScrubbingInputStream.java
@@ -16,18 +16,21 @@ import java.nio.charset.CodingErrorAction;
 public class ScrubbingInputStream extends FilterInputStream {
 
   private static final Logger LOG = LoggerFactory.getLogger(ScrubbingInputStream.class);
+
+  private static final int BUFFER_SIZE = 16_384;
+
   CharsetDecoder decoder = Charset.forName("UTF-8").newDecoder();
   CharsetEncoder encoder = Charset.forName("UTF-8").newEncoder();
-  byte[] readBuffer = new byte[4096];
+  byte[] readBuffer = new byte[BUFFER_SIZE];
   CharBuffer charBuffer, goodCharBuffer;
   ByteBuffer byteBuffer;
 
   public ScrubbingInputStream(InputStream in) {
     super(in);
     decoder.onMalformedInput(CodingErrorAction.IGNORE);
-    byteBuffer = ByteBuffer.allocate(4096);
-    charBuffer = CharBuffer.allocate(4096);
-    goodCharBuffer = CharBuffer.allocate(4096);
+    byteBuffer = ByteBuffer.allocate(BUFFER_SIZE);
+    charBuffer = CharBuffer.allocate(BUFFER_SIZE);
+    goodCharBuffer = CharBuffer.allocate(BUFFER_SIZE);
     byteBuffer.limit(0);
   }
 

--- a/src/main/java/com/patreon/euphrates/ScrubbingInputStream.java
+++ b/src/main/java/com/patreon/euphrates/ScrubbingInputStream.java
@@ -6,90 +6,88 @@ import org.slf4j.LoggerFactory;
 import java.io.FilterInputStream;
 import java.io.IOException;
 import java.io.InputStream;
+import java.nio.ByteBuffer;
+import java.nio.CharBuffer;
+import java.nio.charset.Charset;
+import java.nio.charset.CharsetDecoder;
+import java.nio.charset.CharsetEncoder;
+import java.nio.charset.CodingErrorAction;
 
 public class ScrubbingInputStream extends FilterInputStream {
 
-  private static final Logger LOG = LoggerFactory.getLogger(Replicator.class);
+  private static final Logger LOG = LoggerFactory.getLogger(ScrubbingInputStream.class);
+  CharsetDecoder decoder = Charset.forName("UTF-8").newDecoder();
+  CharsetEncoder encoder = Charset.forName("UTF-8").newEncoder();
+  byte[] readBuffer = new byte[4096];
+  CharBuffer charBuffer, goodCharBuffer;
+  ByteBuffer byteBuffer;
 
   public ScrubbingInputStream(InputStream in) {
     super(in);
+    decoder.onMalformedInput(CodingErrorAction.IGNORE);
+    byteBuffer = ByteBuffer.allocate(4096);
+    charBuffer = CharBuffer.allocate(4096);
+    goodCharBuffer = CharBuffer.allocate(4096);
+    byteBuffer.limit(0);
   }
 
   @Override
   public int read() throws IOException {
-    int b = in.read();
-    return charValid(b) ? b : read();
+    fillBuffer();
+
+    if (!byteBuffer.hasRemaining()) return -1;
+    int b = (int)byteBuffer.get();
+    return b;
   }
 
   @Override
   public int read(byte[] b, int off, int len) throws IOException {
-    int r = in.read(b, off, len);
-    if (r > 0) {
-      int lastChar = off;
-      // scan all chars
-      for (int pos = off; pos < off + r; pos++) {
-        // if invalid
-        if (!charValid(b[pos])) {
-          // find the next valid one
-          for (int nextValid = pos + 1; nextValid < off + r; nextValid++) {
-            // and swapem!
-            if (charValid(b[nextValid])) {
-              byte cc = b[nextValid];
-              b[nextValid] = b[pos];
-              b[pos] = cc;
-              lastChar = pos;
-              break;
-            }
-          }
-        } else {
-          lastChar = pos;
-        }
-      }
-      r += lastChar - (off + r - 1);
+    fillBuffer();
+    if (!byteBuffer.hasRemaining()) {
+      return -1;
     }
-    return r;
+
+    int maxAvailableLength = Math.min(byteBuffer.remaining(), len);
+    byteBuffer.get(b, off, maxAvailableLength);
+    return maxAvailableLength;
   }
 
-  private boolean charValid(int c) {
-    switch (c) {
-      // these characters are forbidden by xml 1.0 which is what mysqldump produces,
-      // however, stream itself is not xml 1.0 compliant, thus, remove control characters
-      // except for the printable ones
-      case 0x0:
-      case 0x1:
-      case 0x2:
-      case 0x3:
-      case 0x4:
-      case 0x5:
-      case 0x6:
-      case 0x7:
-      case 0x8:
-        //case 0x9: tab      \t
-        //case 0xa: new line \n
-      case 0xb:
-      case 0xc:
-        // case 0xd: cr      \r
-      case 0xe:
-      case 0xf:
-      case 0x10:
-      case 0x11:
-      case 0x12:
-      case 0x13:
-      case 0x14:
-      case 0x15:
-      case 0x16:
-      case 0x17:
-      case 0x18:
-      case 0x19:
-      case 0x1a:
-      case 0x1b:
-      case 0x1c:
-      case 0x1d:
-      case 0x1e:
-      case 0x1f:
-        return false;
-      default:
-        return true;
+  private void fillBuffer() throws IOException {
+    if (byteBuffer.hasRemaining()) {
+      return;
     }
+
+    int bytesRead = in.read(readBuffer);
+    boolean eof = bytesRead == -1;
+
+    ByteBuffer bytesIn = ByteBuffer.wrap(readBuffer, 0, eof ? 0 : bytesRead);
+    decoder.decode(bytesIn, charBuffer, eof);
+    if (eof) decoder.flush(charBuffer);
+
+    charBuffer.flip();
+
+    while (charBuffer.hasRemaining()) {
+      char c = charBuffer.get();
+      if (isPrintableChar(c)) {
+        goodCharBuffer.put(c);
+      }
+    }
+    charBuffer.compact();
+
+    goodCharBuffer.flip();
+    byteBuffer.clear();
+    encoder.encode(goodCharBuffer, byteBuffer, eof);
+    if (eof) encoder.flush(byteBuffer);
+
+    byteBuffer.flip();
+    goodCharBuffer.compact();
   }
+
+  public boolean isPrintableChar( char c ) {
+    Character.UnicodeBlock block = Character.UnicodeBlock.of( c );
+    return (!Character.isISOControl(c) || c == '\n' || c == '\t' || c == '\r') &&
+             block != null &&
+             block != Character.UnicodeBlock.SPECIALS;
+  }
+
 }

--- a/src/test/java/com/patreon/euphrates/ScrubbingInputStreamTest.java
+++ b/src/test/java/com/patreon/euphrates/ScrubbingInputStreamTest.java
@@ -44,4 +44,16 @@ public class ScrubbingInputStreamTest extends TestCase {
     assertArrayEquals(new byte[]{9, 10, 13}, output);
   }
 
+  public void testLargeInputScrubbing() throws Exception {
+    byte[] in = new byte[1024 * 1024 * 3];
+    for (int i = 0; i != in.length; i+=6) {
+      System.arraycopy(new byte[]{123, -17, -65, -65, 123, 123}, 0, in, i, 6);
+    }
+
+    ByteArrayInputStream bin = new ByteArrayInputStream(in);
+    ScrubbingInputStream sis = new ScrubbingInputStream(bin);
+    byte[] output = IOUtils.toByteArray(sis);
+    assertEquals(1_572_864, output.length);
+  }
+
 }

--- a/src/test/java/com/patreon/euphrates/ScrubbingInputStreamTest.java
+++ b/src/test/java/com/patreon/euphrates/ScrubbingInputStreamTest.java
@@ -1,0 +1,47 @@
+package com.patreon.euphrates;
+
+import junit.framework.Test;
+import junit.framework.TestCase;
+import junit.framework.TestSuite;
+import org.apache.commons.io.IOUtils;
+
+import java.io.ByteArrayInputStream;
+
+import static org.junit.Assert.*;
+
+public class ScrubbingInputStreamTest extends TestCase {
+
+  public ScrubbingInputStreamTest(String testName) {
+    super(testName);
+  }
+
+  public static Test suite() {
+    return new TestSuite(ScrubbingInputStreamTest.class);
+  }
+
+  public void testScrubbingBytes() throws Exception {
+    byte[] in = {123, 0x10, 123, 0, 0xa, 0xb, 0xc, 123, 122};
+    ByteArrayInputStream bin = new ByteArrayInputStream(in);
+    ScrubbingInputStream sis = new ScrubbingInputStream(bin);
+    byte[] output = IOUtils.toByteArray(sis);
+    assertArrayEquals(new byte[]{123, 123, 0xa, 123, 122}, output);
+  }
+
+  public void testScrubbingMultibytes() throws Exception {
+    byte[] in = {123, -17, -65, -65, 123, 123};
+    ByteArrayInputStream bin = new ByteArrayInputStream(in);
+    ScrubbingInputStream sis = new ScrubbingInputStream(bin);
+    byte[] output = IOUtils.toByteArray(sis);
+    assertArrayEquals(new byte[]{123, 123, 123}, output);
+  }
+
+  public void testScrubbingLowPrintableChars() throws Exception {
+    byte[] in = {0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21,
+      22, 23, 24, 25, 26, 27, 28, 29, 30, 31};
+    ByteArrayInputStream bin = new ByteArrayInputStream(in);
+    ScrubbingInputStream sis = new ScrubbingInputStream(bin);
+    byte[] output = IOUtils.toByteArray(sis);
+    assertArrayEquals(new byte[]{9, 10, 13}, output);
+  }
+
+}


### PR DESCRIPTION
This scrubs multibyte sequences from the inputstream which the xml parser complains about.

Probably in the future, we should subclass `com.ctc.wstx.io.UTF8Reader` and change its behavior and find some way to use that instead.