### PR TITLE
Use IAM role instead of AWS credentials

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,8 +53,7 @@ Create a valid config.json and run using `mvn exec:exec`.
   "s3": {
     "bucket": "some-transfer-bucket",
     "region": "us-east-1",
-    "accessKey": "xxx",
-    "secretKey": "xxx",
+    "iamRole": "arn:aws:iam::XXXXX:role/euphrates",
     "minimumSegmentSize": 20000000
   }
 }

--- a/src/main/java/com/patreon/euphrates/Config.java
+++ b/src/main/java/com/patreon/euphrates/Config.java
@@ -107,8 +107,6 @@ public class Config {
     final public String bucket;
     final public String iamRole;
     final public String region;
-    final public String accessKey;
-    final public String secretKey;
     final public int minimumSegmentSize;
 
     @JsonCreator
@@ -116,14 +114,10 @@ public class Config {
                @JsonProperty("bucket") String bucket,
                @JsonProperty("region") String region,
                @JsonProperty("iamRole") String iamRole,
-               @JsonProperty("accessKey") String accessKey,
-               @JsonProperty("secretKey") String secretKey,
                @JsonProperty("minimumSegmentSize") int minimumSegmentSize) {
       this.bucket = bucket;
       this.iamRole = iamRole;
       this.region = region;
-      this.accessKey = accessKey;
-      this.secretKey = secretKey;
       this.minimumSegmentSize = minimumSegmentSize;
     }
   }

--- a/src/main/java/com/patreon/euphrates/Config.java
+++ b/src/main/java/com/patreon/euphrates/Config.java
@@ -115,7 +115,7 @@ public class Config {
     public S3(
                @JsonProperty("bucket") String bucket,
                @JsonProperty("region") String region,
-               @JsonProperty("accessKey") String iamRole,
+               @JsonProperty("iamRole") String iamRole,
                @JsonProperty("accessKey") String accessKey,
                @JsonProperty("secretKey") String secretKey,
                @JsonProperty("minimumSegmentSize") int minimumSegmentSize) {

--- a/src/main/java/com/patreon/euphrates/Config.java
+++ b/src/main/java/com/patreon/euphrates/Config.java
@@ -105,6 +105,7 @@ public class Config {
 
   public static class S3 {
     final public String bucket;
+    final public String iamRole;
     final public String region;
     final public String accessKey;
     final public String secretKey;
@@ -114,10 +115,12 @@ public class Config {
     public S3(
                @JsonProperty("bucket") String bucket,
                @JsonProperty("region") String region,
+               @JsonProperty("accessKey") String iamRole,
                @JsonProperty("accessKey") String accessKey,
                @JsonProperty("secretKey") String secretKey,
                @JsonProperty("minimumSegmentSize") int minimumSegmentSize) {
       this.bucket = bucket;
+      this.iamRole = iamRole;
       this.region = region;
       this.accessKey = accessKey;
       this.secretKey = secretKey;

--- a/src/main/java/com/patreon/euphrates/Redshift.java
+++ b/src/main/java/com/patreon/euphrates/Redshift.java
@@ -55,9 +55,8 @@ public class Redshift {
         String.format("COPY %s.%s\n", config.redshift.schema, Util.tempTable(table))
           + String.format("FROM 's3://%s/%s'\n", config.s3.bucket, manifestPath)
           + String.format(
-          "CREDENTIALS 'aws_access_key_id=%s;aws_secret_access_key=%s'\n",
-          config.s3.accessKey,
-          config.s3.secretKey)
+          "IAM_ROLE '%s'\n",
+          config.s3.iamRole)
           + String.format(
           "json 's3://%s/%s' gzip TIMEFORMAT AS 'auto' ACCEPTANYDATE TRUNCATECOLUMNS MANIFEST",
           config.s3.bucket,


### PR DESCRIPTION
Use an IAM role to authenticate to redshift instead of using AWS
credentials.

INFRA-64

See docs at https://docs.aws.amazon.com/redshift/latest/dg/copy-parameters-authorization.html