### PR TITLE
When queueing copy jobs, use offer instead of add

### DIFF
--- a/src/main/java/com/patreon/euphrates/S3Writer.java
+++ b/src/main/java/com/patreon/euphrates/S3Writer.java
@@ -64,7 +64,7 @@ public class S3Writer {
 
   protected void enqueueKey(Config.Table table, String key, ReusableCountLatch finished) {
     CopyJob job = new CopyJob(table, key, finished);
-    this.copyQueues.get(table.name).add(job);
+    this.copyQueues.get(table.name).offer(job);
   }
 
   protected int getCopyQueueSum() {


### PR DESCRIPTION
`interface <BlockingQeue<T>.add()` will throw an exception if the queue
is full.

 Use `offer()` instead as per docs: https://docs.oracle.com/javase/7/docs/api/java/util/concurrent/BlockingQueue.html#add(E)