### PR TITLE
INFRA-128 Build Euphrates in CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -55,13 +55,13 @@ jobs:
         at: /tmp/workspace
 
     - deploy:
-        command: "aws s3 cp /tmp/workspace/target/com-patreon-euphrates-*.jar s3://${BUCKET}/euphrates/branch/${CIRCLE_BRANCH}/euphrates-latest.jar"
+        command: "aws s3 cp /tmp/workspace/target/euphrates-*.jar s3://${BUCKET}/euphrates/branch/${CIRCLE_BRANCH}/euphrates-latest.jar"
 
     - deploy:
-        command: "aws s3 cp /tmp/workspace/target/com-patreon-euphrates-*.jar s3://${BUCKET}/euphrates/branch/${CIRCLE_BRANCH}/"
+        command: "aws s3 cp /tmp/workspace/target/euphrates-*.jar s3://${BUCKET}/euphrates/branch/${CIRCLE_BRANCH}/"
 
     - deploy:
-        command: "aws s3 cp /tmp/workspace/target/com-patreon-euphrates-*.jar s3://${BUCKET}/euphrates/sha/"
+        command: "aws s3 cp /tmp/workspace/target/euphrates-*.jar s3://${BUCKET}/euphrates/sha/"
 
 workflows:
   version: 2

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,40 +1,73 @@
-# Java Maven CircleCI 2.0 configuration file
-#
-# Check https://circleci.com/docs/2.0/language-java/ for more details
 version: 2
 jobs:
   build:
+    working_directory: ~/java
+    parallelism: 1
     docker:
-      # specify the version you desire here
-      - image: circleci/openjdk:8-jdk
-
-      # Specify service dependencies here if necessary
-      # CircleCI maintains a library of pre-built images
-      # documented at https://circleci.com/docs/2.0/circleci-images/
-      # - image: circleci/postgres:9.4
-
-    working_directory: ~/repo
+    - image: circleci/openjdk:8
 
     environment:
       # Customize the JVM maximum heap limit
       MAVEN_OPTS: -Xmx3200m
 
     steps:
-      - checkout
+    - checkout
 
-      # Download and cache dependencies
-      - restore_cache:
-          keys:
-          - v1-dependencies-{{ checksum "pom.xml" }}
-          # fallback to using the latest cache if no exact match is found
-          - v1-dependencies-
+    - restore_cache:
+        key: v1-java-maven-{{ checksum "pom.xml" }}
 
-      - run: mvn dependency:go-offline
+    - run:
+        name: Compile the code
+        command: mvn compile
 
-      - save_cache:
-          paths:
-            - ~/.m2
-          key: v1-dependencies-{{ checksum "pom.xml" }}
+    - run:
+        name: Run tests
+        command: mvn test
 
-      # run tests!
-      - run: mvn test
+    - save_cache:
+        key: v1-java-maven-{{ checksum "pom.xml" }}
+        paths:
+        - ~/.m2
+
+    - store_test_results:
+        path: ~/java/target/surefire-reports
+
+    - run: mvn package
+    - run: mkdir -p workspace
+    - persist_to_workspace:
+        root: ~/java
+        paths:
+          - target
+  deploy:
+    working_directory: ~/java
+    parallelism: 1
+    docker:
+    - image: circleci/openjdk:8
+
+    steps:
+    - run:
+        command: |
+          sudo apt-get update
+          sudo apt-get install -y python-pip
+          sudo pip install awscli --upgrade
+
+    - attach_workspace:
+        at: /tmp/workspace
+
+    - deploy:
+        command: "aws s3 cp /tmp/workspace/target/com-patreon-euphrates-*.jar s3://${BUCKET}/euphrates/branch/${CIRCLE_BRANCH}/euphrates-latest.jar"
+
+    - deploy:
+        command: "aws s3 cp /tmp/workspace/target/com-patreon-euphrates-*.jar s3://${BUCKET}/euphrates/branch/${CIRCLE_BRANCH}/"
+
+    - deploy:
+        command: "aws s3 cp /tmp/workspace/target/com-patreon-euphrates-*.jar s3://${BUCKET}/euphrates/sha/"
+
+workflows:
+  version: 2
+  build-and-deploy:
+    jobs:
+    - build
+    - deploy:
+        requires:
+        - build

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
     <modelVersion>4.0.0</modelVersion>
 
     <groupId>com.patreon.euphrates</groupId>
-    <artifactId>com-patreon-euphrates</artifactId>
+    <artifactId>euphrates</artifactId>
     <version>1.0</version>
     <packaging>jar</packaging>
 
@@ -40,6 +40,11 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
+            <version>2.8.0</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.dataformat</groupId>
+            <artifactId>jackson-dataformat-yaml</artifactId>
             <version>2.8.0</version>
         </dependency>
         <!-- https://mvnrepository.com/artifact/org.apache.commons/commons-dbcp2 -->

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
     <groupId>com.patreon.euphrates</groupId>
     <artifactId>com-patreon-euphrates</artifactId>
-    <version>1.0-SNAPSHOT</version>
+    <version>1.0</version>
     <packaging>jar</packaging>
 
     <name>com-patreon-euphrates</name>
@@ -102,6 +102,8 @@
     </dependencies>
 
     <build>
+        <finalName>${project.artifactId}-${project.version}-${git.commit.id}</finalName>
+
         <resources>
             <resource>
                 <directory>src/main/config</directory>
@@ -117,6 +119,43 @@
                     <source>1.8</source>
                     <target>1.8</target>
                     <compilerArgument>-Xlint:unchecked</compilerArgument>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>pl.project13.maven</groupId>
+                <artifactId>git-commit-id-plugin</artifactId>
+                <version>2.2.5</version>
+                <executions>
+                    <execution>
+                        <id>get-the-git-infos</id>
+                        <goals>
+                            <goal>revision</goal>
+                        </goals>
+                        <phase>validate</phase>
+                    </execution>
+                    <execution>
+                        <id>validate-the-git-infos</id>
+                        <goals>
+                            <goal>validateRevision</goal>
+                        </goals>
+                        <phase>validate</phase>
+                    </execution>
+                </executions>
+
+                <configuration>
+                    <dotGitDirectory>${project.basedir}/.git</dotGitDirectory>
+                    <useNativeGit>true</useNativeGit>
+                    <commitIdGenerationMode>flat</commitIdGenerationMode>
+                    <generateGitPropertiesFile>true</generateGitPropertiesFile>
+                    <generateGitPropertiesFilename>${project.build.outputDirectory}/build-info.json</generateGitPropertiesFilename>
+                    <format>json</format>
+                    <validationProperties>
+                        <validationProperty>
+                            <name>validating project version</name>
+                            <value>${project.version}</value>
+                            <shouldMatchTo><![CDATA[^.*(?<!-SNAPSHOT)$]]></shouldMatchTo>
+                        </validationProperty>
+                    </validationProperties>
                 </configuration>
             </plugin>
             <plugin>
@@ -150,6 +189,7 @@
                             <goal>shade</goal>
                         </goals>
                         <configuration>
+                            <createDependencyReducedPom>false</createDependencyReducedPom>
                             <filters>
                                 <filter>
                                     <artifact>*:*</artifact>
@@ -160,8 +200,10 @@
                                     </excludes>
                                 </filter>
                             </filters>
-                            <shadedArtifactAttached>true</shadedArtifactAttached>
+                            <shadedArtifactAttached>false</shadedArtifactAttached>
                             <transformers>
+                                <transformer
+                                        implementation="com.github.edwgiz.mavenShadePlugin.log4j2CacheTransformer.PluginsCacheFileTransformer"/>
                                 <transformer
                                         implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">
                                     <mainClass>com.patreon.euphrates.App</mainClass>
@@ -170,6 +212,13 @@
                         </configuration>
                     </execution>
                 </executions>
+                <dependencies>
+                    <dependency>
+                        <groupId>com.github.edwgiz</groupId>
+                        <artifactId>maven-shade-plugin.log4j2-cachefile-transformer</artifactId>
+                        <version>2.8.1</version>
+                    </dependency>
+                </dependencies>
             </plugin>
         </plugins>
     </build>

--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
     <version>1.0</version>
     <packaging>jar</packaging>
 
-    <name>com-patreon-euphrates</name>
+    <name>euphrates</name>
     <url>http://maven.apache.org</url>
 
     <properties>

--- a/src/main/config/log4j2.properties
+++ b/src/main/config/log4j2.properties
@@ -1,7 +1,0 @@
-status=error
-dest=err
-
-appender.console.type = Console
-appender.console.name = STDOUT
-appender.console.layout.type = PatternLayout
-appender.console.layout.pattern=%5p [%t] (%F:%L) - %m%n

--- a/src/main/config/log4j2.yaml
+++ b/src/main/config/log4j2.yaml
@@ -1,0 +1,30 @@
+---
+Configuration:
+  status: warn
+  name: Euphrates
+  properties:
+    property:
+      name: euphratesLog
+      value: euphrates.log
+  thresholdFilter:
+    level: debug
+  appenders:
+    File:
+      name: File
+      fileName: ${sys:euphratesLog}
+      PatternLayout:
+        Pattern: "[%-5p] %d %c - %m%n"
+      Filters:
+        ThresholdFilter:
+          level: debug
+  Loggers:
+    logger:
+      - name: com.patreon.euphrates
+        level: debug
+        additivity: false
+        AppenderRef:
+          ref: File
+    Root:
+      level: warn
+      AppenderRef:
+        ref: File

--- a/src/main/java/com/patreon/euphrates/TableCopier.java
+++ b/src/main/java/com/patreon/euphrates/TableCopier.java
@@ -59,6 +59,7 @@ class TableCopier implements Runnable {
 
       LOG.info(String.format("Running a mysqldump for %s", dumpargs));
 
+      // TODO feed stderr to a logger via redirectError so we catch errors from mysqldump
       Process dumpProcess =
         new ProcessBuilder(dumpargs)
           .redirectError(ProcessBuilder.Redirect.INHERIT)


### PR DESCRIPTION
- Build shaded JAR in CI
- Copy shaded JAR to S3
- Add git SHA info to build and to filename
- Preserve log4j configuration files in shaded jar
- Use build and deploy workflow, sharing the artifacts in a workspace
- Use YAML configuration for Log4j2
- Allow system property `euphratesLog` to set destination